### PR TITLE
Support Elastic Common Schema fields

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -17,8 +17,8 @@ impl LogSettings {
   pub fn new_default_settings() -> LogSettings {
     LogSettings {
       message_keys: vec!["short_message".to_string(), "msg".to_string(), "message".to_string()],
-      time_keys: vec!["timestamp".to_string(), "time".to_string()],
-      level_keys: vec!["level".to_string(), "severity".to_string()],
+      time_keys: vec!["timestamp".to_string(), "time".to_string(), "@timestamp".to_string()],
+      level_keys: vec!["level".to_string(), "severity".to_string(), "log.level".to_string()],
       additional_values: vec![],
       dump_all: false,
       inspect: false,


### PR DESCRIPTION
Last year elastic introduced [elastic common schema](https://www.elastic.co/guide/en/ecs/current/index.html). Basically, it is a syntactic and semantic convention for structured logging.

This patch add support of ECS time (`@timestamp`) and level (`logger.level`) fields. Message is already fine. 

Other alternative fields were untested so I didn't add an unit test.

```
$ cat /tmp/test4
{"@timestamp":"2020-02-24T11:34:38.483Z", "log.level": "INFO", "message":"My message", "process.thread.name":"main","log.logger":"com.greencomnetworks.poc.Removeme","container.id":"thinkpad","service.type":"test","service.version":"N/A"}
$ cargo run /tmp/test4 
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/fblog /tmp/test4`
2020-02-24T11:34:38  INFO: My message
```