### PR TITLE
add message placeholder substitution

### DIFF
--- a/README.org
+++ b/README.org
@@ -82,6 +82,23 @@
 
    [[https://no-color.org/][no-color]]
 
+** Message placeholder substitution
+   Placeholders in the message (~fblog_message~) can be substituted with their corresponding values in a context object or array.
+   To enable substitutions, pass the ~-s~ flag or either set context key (~-c context~) or placeholder format (~-F {{key}}~).
+
+   Note that the placeholder format should be written like ~<PREFIX>key<SUFFIX>~, where it would match a placeholder with the key ~key~.
+   
+   Example:
+   #+BEGIN_SRC json
+   {"message": "Found #{count} new items.", "extra_data": {"count": 556}, "level": "info"}
+   #+END_SRC
+
+   #+BEGIN_SRC bash
+   fblog -c extra_data -F '#{key}' example.log
+   #+END_SRC
+
+   Result:
+   [[./res/placeholder-example1.svg]]
 
 ** Installation
    #+BEGIN_SRC bash

--- a/README.org
+++ b/README.org
@@ -84,20 +84,23 @@
 
 ** Message placeholder substitution
    Placeholders in the message (~fblog_message~) can be substituted with their corresponding values in a context object or array.
-   To enable substitutions, pass the ~-s~ flag or either set context key (~-c context~) or placeholder format (~-F {{key}}~).
+   To enable substitutions, pass the ~-s~ flag or either set context key (~-c context~) or placeholder format (~-F {key}~).
 
    Note that the placeholder format should be written like ~<PREFIX>key<SUFFIX>~, where it would match a placeholder with the key ~key~.
    
-   Example:
+*** Example
+   Given the following log (referred to as ~example.log~):
    #+BEGIN_SRC json
    {"message": "Found #{count} new items.", "extra_data": {"count": 556}, "level": "info"}
    #+END_SRC
 
+   Running with the following arguments:
    #+BEGIN_SRC bash
    fblog -c extra_data -F '#{key}' example.log
    #+END_SRC
 
    Result:
+   
    [[./res/placeholder-example1.svg]]
 
 ** Installation

--- a/res/placeholder-example1.svg
+++ b/res/placeholder-example1.svg
@@ -1,0 +1,35 @@
+<svg viewBox="0 0 376 16" width="376" height="16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <style>
+        rect { shape-rendering: crispEdges; }
+        text {
+            dominant-baseline: text-before-edge;
+            white-space: pre;
+            font: 14px Courier, monospace;
+            fill: #bbbbbb;
+        }
+        .u { text-decoration: underline; }
+    </style>
+    <rect width="100%" height="100%" x="0" y="0" style="fill: #000000"/>
+    <text x="168" y="0" style="fill: #50ff50">I</text>
+    <text x="176" y="0" style="fill: #50ff50">N</text>
+    <text x="184" y="0" style="fill: #50ff50">F</text>
+    <text x="192" y="0" style="fill: #50ff50">O</text>
+    <text x="200" y="0">:</text>
+    <text x="216" y="0">F</text>
+    <text x="224" y="0">o</text>
+    <text x="232" y="0">u</text>
+    <text x="240" y="0">n</text>
+    <text x="248" y="0">d</text>
+    <text x="264" y="0" style="fill: #50ffff">5</text>
+    <text x="272" y="0" style="fill: #50ffff">5</text>
+    <text x="280" y="0" style="fill: #50ffff">6</text>
+    <text x="296" y="0">n</text>
+    <text x="304" y="0">e</text>
+    <text x="312" y="0">w</text>
+    <text x="328" y="0">i</text>
+    <text x="336" y="0">t</text>
+    <text x="344" y="0">e</text>
+    <text x="352" y="0">m</text>
+    <text x="360" y="0">s</text>
+    <text x="368" y="0">.</text>
+</svg>

--- a/sample_context.log
+++ b/sample_context.log
@@ -1,0 +1,7 @@
+{"message": "The {type} was updated with {added} added, {removed} removed and {changed} changed! Forced: {forced}.", "context": { "changed": 3, "added": 0, "removed": 1, "type": "bartok", "forced": false }, "time":"Sat May 13 17:50:00 CEST 2023", "level": "info"}
+{"message": "The {type} was updated with {added} added, {removed} removed and {changed} changed! Forced: {forced}.", "context": { "changed": 2, "added": 1, "removed": 0, "type": "kikiki", "forced": true }, "time":"Sat May 13 17:51:00 CEST 2023", "level": "info"}
+{"message": "The {type} was updated with {added} added, {removed} removed and {changed} changed! Forced: {forced}.", "context": { "changed": 35, "added": 3, "removed": 10, "type": "dolbas", "forced": false }, "time":"Sat May 13 17:52:00 CEST 2023", "level": "info"}
+{"message": "{0} new items could not be registered: {1}", "context": [3, ["rullo", "opeth", "leda"]], "time":"Sat May 13 18:03:10 CEST 2023", "level": "error"}
+{"message": "Insufficient storage! {0} item(s) skipped!", "context": [423], "time":"Sat May 13 18:10:34 CEST 2023", "level": "warning"}
+{"message": "The key {key} was not found in the context!", "context": {"unused": "I have so much to contribute!"}, "time":"Sat May 13 18:12:02 CEST 2023", "level": "warning"}
+{"message": "A new type of item was discovered: {item}", "context": {"item": {"name": "Merobiba", "princess": true, "age": 12 } }, "time":"Sat May 13 18:21:58 CEST 2023", "level": "info"}

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,6 @@
+use crate::substitution::Substitution;
 use crate::template;
+use clap::builder::ArgPredicate;
 use clap::{crate_version, ArgAction};
 use clap::{Arg, Command};
 
@@ -108,19 +110,28 @@ pub fn app() -> Command {
         .help("Formats the additional value fblog output."),
     )
     .arg(
+      Arg::new("enable-substitution")
+        .long("substitute")
+        .short('s')
+        .action(ArgAction::SetTrue)
+        .help("Enable substitution of placeholders in the log messages with their corresponding values from the context.")
+    )
+    .arg(
       Arg::new("context-key")
         .long("context-key")
         .short('c')
         .num_args(1)
         .action(ArgAction::Set)
+        .default_value_if("enable-substitution", ArgPredicate::IsPresent, Substitution::DEFAULT_CONTEXT_KEY)
         .help("Use this key as the source of substitutions for the message. Value can either be an array ({1}) or an object ({key})."),
     )
     .arg(
-      Arg::new("message-template-format")
-        .long("message-template-format")
+      Arg::new("placeholder-format")
+        .long("placeholder-format")
         .short('F')
         .num_args(1)
         .action(ArgAction::Set)
+        .default_value_if("enable-substitution", ArgPredicate::IsPresent, Substitution::DEFAULT_PLACEHOLDER_FORMAT)
         .help("The format that should be used for substituting values in the message, where the key is the literal word `key`. Example: [[key]] or ${key}."),
     )
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -114,7 +114,7 @@ pub fn app() -> Command {
         .long("substitute")
         .short('s')
         .action(ArgAction::SetTrue)
-        .help("Enable substitution of placeholders in the log messages with their corresponding values from the context.")
+        .help("Enable substitution of placeholders in the log messages with their corresponding values from the context."),
     )
     .arg(
       Arg::new("context-key")

--- a/src/app.rs
+++ b/src/app.rs
@@ -107,4 +107,20 @@ pub fn app() -> Command {
         .default_value(template::DEFAULT_ADDITIONAL_VALUE_FORMAT)
         .help("Formats the additional value fblog output."),
     )
+    .arg(
+      Arg::new("context-key")
+        .long("context-key")
+        .short('c')
+        .num_args(1)
+        .action(ArgAction::Set)
+        .help("Use this key as the source of substitutions for the message. Value can either be an array ({1}) or an object ({key})."),
+    )
+    .arg(
+      Arg::new("message-template-format")
+        .long("message-template-format")
+        .short('F')
+        .num_args(1)
+        .action(ArgAction::Set)
+        .help("The format that should be used for substituting values in the message, where the key is the literal word `key`. Example: [[key]] or ${key}."),
+    )
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,5 @@
 use crate::substitution::Substitution;
 use crate::template;
-use clap::builder::ArgPredicate;
 use clap::{crate_version, ArgAction};
 use clap::{Arg, Command};
 
@@ -122,7 +121,7 @@ pub fn app() -> Command {
         .short('c')
         .num_args(1)
         .action(ArgAction::Set)
-        .default_value_if("enable-substitution", ArgPredicate::IsPresent, Substitution::DEFAULT_CONTEXT_KEY)
+        .default_value_if("enable-substitution", "true", Substitution::DEFAULT_CONTEXT_KEY)
         .help("Use this key as the source of substitutions for the message. Value can either be an array ({1}) or an object ({key})."),
     )
     .arg(
@@ -131,7 +130,7 @@ pub fn app() -> Command {
         .short('F')
         .num_args(1)
         .action(ArgAction::Set)
-        .default_value_if("enable-substitution", ArgPredicate::IsPresent, Substitution::DEFAULT_PLACEHOLDER_FORMAT)
+        .default_value_if("enable-substitution", "true", Substitution::DEFAULT_PLACEHOLDER_FORMAT)
         .help("The format that should be used for substituting values in the message, where the key is the literal word `key`. Example: [[key]] or ${key}."),
     )
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -208,8 +208,7 @@ fn write_additional_values(out: &mut dyn Write, log_entry: &BTreeMap<String, Str
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::template;
-  use regex::Regex;
+  use crate::{template, no_color_support::without_style};
 
   fn fblog_handlebar_registry_default_format() -> Handlebars<'static> {
     let main_line_format = template::DEFAULT_MAIN_LINE_FORMAT.to_string();
@@ -219,10 +218,8 @@ mod tests {
   }
 
   fn out_to_string(out: Vec<u8>) -> String {
-    let regex = Regex::new("\u{001B}\\[[\\d;]*[^\\d;]").expect("Regex should be valid");
     let out_with_style = String::from_utf8_lossy(&out).into_owned();
-    let result = regex.replace_all(&out_with_style, "").into_owned();
-    result
+    without_style(&out_with_style)
   }
 
   #[test]

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,5 +1,5 @@
-use crate::substitution::Substitution;
 use crate::no_color_support::style;
+use crate::substitution::Substitution;
 use handlebars::Handlebars;
 use serde_json::{Map, Value};
 use std::borrow::ToOwned;
@@ -60,7 +60,6 @@ impl LogSettings {
   pub fn add_substitution(&mut self, message_template: Substitution) {
     self.substitution = Some(message_template)
   }
-
 }
 
 pub fn print_log_line(
@@ -208,7 +207,7 @@ fn write_additional_values(out: &mut dyn Write, log_entry: &BTreeMap<String, Str
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{template, no_color_support::without_style};
+  use crate::{no_color_support::without_style, template};
 
   fn fblog_handlebar_registry_default_format() -> Handlebars<'static> {
     let main_line_format = template::DEFAULT_MAIN_LINE_FORMAT.to_string();

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,4 +1,4 @@
-use crate::message_template::{FormatError, MessageTemplate};
+use crate::substitution::Substitution;
 use crate::no_color_support::style;
 use handlebars::Handlebars;
 use serde_json::{Map, Value};
@@ -16,7 +16,7 @@ pub struct LogSettings {
   pub dump_all: bool,
   pub with_prefix: bool,
   pub print_lua: bool,
-  pub message_template: Option<MessageTemplate>,
+  pub substitution: Option<Substitution>,
 }
 
 impl LogSettings {
@@ -30,7 +30,7 @@ impl LogSettings {
       dump_all: false,
       with_prefix: false,
       print_lua: false,
-      message_template: None,
+      substitution: None,
     }
   }
 
@@ -57,18 +57,10 @@ impl LogSettings {
     self.excluded_values.append(&mut excluded_values);
   }
 
-  pub fn add_message_template(&mut self, message_template: MessageTemplate) {
-    self.message_template = Some(message_template)
+  pub fn add_substitution(&mut self, message_template: Substitution) {
+    self.substitution = Some(message_template)
   }
 
-  pub fn set_message_template_format(&mut self, format: &str) -> Result<(), FormatError> {
-    if let Some(message_template) = &mut self.message_template {
-      message_template.set_key_format(format)?;
-    } else {
-      self.message_template = Some(MessageTemplate::default().with_key_format(format)?);
-    }
-    Ok(())
-  }
 }
 
 pub fn print_log_line(
@@ -85,7 +77,7 @@ pub fn print_log_line(
   let mut message = get_string_value_or_default(&string_log_entry, &log_settings.message_keys, "");
   let timestamp = get_string_value_or_default(&string_log_entry, &log_settings.time_keys, "");
 
-  if let Some(message_template) = &log_settings.message_template {
+  if let Some(message_template) = &log_settings.substitution {
     if let Some(templated_message) = message_template.apply(&message, log_entry) {
       message = templated_message;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,13 @@ extern crate regex;
 mod app;
 mod filter;
 mod log;
+mod message_template;
 mod no_color_support;
 mod process;
 mod template;
 
 use crate::log::LogSettings;
+use message_template::MessageTemplate;
 use std::fs;
 
 fn main() {
@@ -33,6 +35,16 @@ fn main() {
 
   if let Some(values) = matches.get_many::<String>("level-key") {
     log_settings.add_level_keys(values.map(ToString::to_string).collect());
+  }
+
+  if let Some(context) = matches.get_one::<String>("context-key") {
+    log_settings.add_message_template(MessageTemplate::new(context.clone()))
+  }
+
+  if let Some(format) = matches.get_one::<String>("message-template-format") {
+    if let Err(e) = log_settings.set_message_template_format(format) {
+      panic!("Invalid message template format: {}", e)
+    }
   }
 
   log_settings.dump_all = matches.get_flag("dump-all");

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,14 +6,14 @@ extern crate regex;
 mod app;
 mod filter;
 mod log;
-mod substitution;
 mod no_color_support;
 mod process;
+mod substitution;
 mod template;
 
 use crate::log::LogSettings;
-use substitution::Substitution;
 use std::fs;
+use substitution::Substitution;
 
 fn main() {
   let app = app::app();
@@ -41,13 +41,11 @@ fn main() {
     (None, None) => {
       // Neither context key nor placeholder is set, meaning that substitution is not enabled
       // since setting the flag sets the defaults for those arguments
-    },
-    (context, format) => {
-      match Substitution::new(context, format) {
-        Err(e) => panic!("Invalid placeholder format: {}", e),
-        Ok(subst) => log_settings.add_substitution(subst)
-      }
     }
+    (context, format) => match Substitution::new(context, format) {
+      Err(e) => panic!("Invalid placeholder format: {}", e),
+      Ok(subst) => log_settings.add_substitution(subst),
+    },
   }
 
   log_settings.dump_all = matches.get_flag("dump-all");

--- a/src/message_template.rs
+++ b/src/message_template.rs
@@ -1,0 +1,152 @@
+use std::fmt::Write;
+
+use regex::{Captures, Regex};
+use serde_json::Value;
+use yansi::Color;
+
+use crate::no_color_support::stylew;
+
+#[derive(Debug)]
+pub enum FormatError {
+  MissingIdentifier,
+  RegexParse(regex::Error),
+}
+
+impl From<regex::Error> for FormatError {
+  fn from(value: regex::Error) -> Self {
+    Self::RegexParse(value)
+  }
+}
+
+impl std::fmt::Display for FormatError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      Self::MissingIdentifier => f.write_str("The identifier `key` is missing"),
+      Self::RegexParse(rx) => f.write_fmt(format_args!("Regular expression could not be created for format: {}", rx)),
+    }
+  }
+}
+
+/// 7 bytes for color (`\e` `[` `1` `;` `3` `9` `m`) and 4 bytes for reset (`\e` `[` `0` `m`)
+const COLOR_OVERHEAD: usize = 7 + 4;
+
+pub struct MessageTemplate {
+  pub context: String,
+  key_prefix: String,
+  key_suffix: String,
+  key_regex: Regex,
+}
+
+impl MessageTemplate {
+  const DEFAULT_KEY_PREFIX: &str = "{";
+  const DEFAULT_KEY_SUFFIX: &str = "}";
+  const DEFAULT_CONTEXT: &str = "context";
+
+  pub fn new(context: String) -> Self {
+    let key_prefix = Self::DEFAULT_KEY_PREFIX.to_owned();
+    let key_suffix = Self::DEFAULT_KEY_SUFFIX.to_owned();
+    let key_regex = Self::create_regex(&key_prefix, &key_suffix).expect("default key should compile");
+    Self {
+      context,
+      key_prefix,
+      key_suffix,
+      key_regex,
+    }
+  }
+
+  pub fn set_key_format(&mut self, format: &str) -> Result<(), FormatError> {
+    let (prefix, suffix) = format.split_once("key").ok_or_else(|| FormatError::MissingIdentifier)?;
+    self.key_regex = Self::create_regex(prefix, suffix)?;
+    self.key_prefix = prefix.to_owned();
+    self.key_suffix = suffix.to_owned();
+    Ok(())
+  }
+
+  pub fn with_key_format(mut self, format: &str) -> Result<Self, FormatError> {
+    self.set_key_format(format)?;
+    Ok(self)
+  }
+
+  fn create_regex(prefix: &str, suffix: &str) -> Result<Regex, regex::Error> {
+    Regex::new(&format!("{}([a-z|A-Z|0-9|_|-]+){}", regex::escape(prefix), regex::escape(suffix)))
+  }
+
+  pub(crate) fn apply(&self, message: &str, log_entry: &serde_json::Map<String, serde_json::Value>) -> Option<String> {
+    let Some(context_value) = log_entry.get(&self.context) else {
+      return None;
+    };
+
+    let key_format_overhead = &self.key_prefix.len() + COLOR_OVERHEAD + &self.key_suffix.len() + COLOR_OVERHEAD;
+
+    return Some(
+      self
+        .key_regex
+        .replace_all(message, |caps: &Captures| {
+          let key = &caps[1];
+          let value = match context_value {
+            Value::Object(o) => o.get(key),
+            Value::Array(a) => key.parse().and_then(|i| Ok(a.get::<usize>(i))).unwrap_or(None),
+            _ => None,
+          };
+          match value {
+            None => {
+              let mut buf = String::with_capacity(key.len() + COLOR_OVERHEAD + key_format_overhead);
+              stylew(&mut buf, &Color::Default.style().dimmed(), &self.key_prefix);
+              stylew(&mut buf, &Color::Red.style().bold(), key);
+              stylew(&mut buf, &Color::Default.style().dimmed(), &self.key_suffix);
+              buf
+            }
+            Some(value) => {
+              let mut buf = String::new();
+              self.color_format(&mut buf, value);
+              buf
+            }
+          }
+        })
+        .into_owned(),
+    );
+  }
+
+  fn color_format(&self, buf: &mut String, value: &Value) {
+    match value {
+      Value::String(s) => stylew(buf, &Color::Yellow.style().bold(), s),
+      Value::Number(n) => stylew(buf, &Color::Cyan.style().bold(), &n.to_string()),
+      Value::Array(a) => self.color_format_array(buf, a),
+      Value::Object(o) => self.color_format_map(buf, o),
+      Value::Bool(true) => stylew(buf, &Color::Green.style().bold(), "true"),
+      Value::Bool(false) => stylew(buf, &Color::Red.style().bold(), "false"),
+      Value::Null => stylew(buf, &Color::Default.style().bold(), "null"),
+    }
+  }
+
+  fn color_format_array(&self, mut buf: &mut String, a: &[Value]) {
+    stylew(&mut buf, &Color::Default.style().dimmed(), "[");
+    for (i, value) in a.iter().enumerate() {
+      if i > 0 {
+        _ = buf.write_str(", ");
+      }
+      self.color_format(&mut buf, value);
+    }
+    stylew(buf, &Color::Default.style().dimmed(), "]");
+  }
+
+  fn color_format_map(&self, mut buf: &mut String, o: &serde_json::Map<String, Value>) {
+    stylew(&mut buf, &Color::Default.style().dimmed(), "{");
+    for (i, (key, value)) in o.iter().enumerate() {
+      if i > 0 {
+        _ = buf.write_char(',');
+      }
+      _ = buf.write_char(' ');
+      stylew(&mut buf, &Color::Magenta.style(), key);
+      stylew(&mut buf, &Color::Default.style().dimmed(), ": ");
+      self.color_format(buf, value);
+    }
+    stylew(buf, &Color::Default.style().dimmed(), " }");
+  }
+}
+
+impl Default for MessageTemplate {
+  fn default() -> Self {
+    Self::new(Self::DEFAULT_CONTEXT.into())
+  }
+}

--- a/src/message_template.rs
+++ b/src/message_template.rs
@@ -55,7 +55,7 @@ impl MessageTemplate {
   }
 
   pub fn set_key_format(&mut self, format: &str) -> Result<(), FormatError> {
-    let (prefix, suffix) = format.split_once("key").ok_or_else(|| FormatError::MissingIdentifier)?;
+    let (prefix, suffix) = format.split_once("key").ok_or(FormatError::MissingIdentifier)?;
     self.key_regex = Self::create_regex(prefix, suffix)?;
     self.key_prefix = prefix.to_owned();
     self.key_suffix = suffix.to_owned();
@@ -76,7 +76,7 @@ impl MessageTemplate {
       return None;
     };
 
-    let key_format_overhead = &self.key_prefix.len() + COLOR_OVERHEAD + &self.key_suffix.len() + COLOR_OVERHEAD;
+    let key_format_overhead = self.key_prefix.len() + COLOR_OVERHEAD + self.key_suffix.len() + COLOR_OVERHEAD;
 
     return Some(
       self
@@ -85,7 +85,7 @@ impl MessageTemplate {
           let key = &caps[1];
           let value = match context_value {
             Value::Object(o) => o.get(key),
-            Value::Array(a) => key.parse().and_then(|i| Ok(a.get::<usize>(i))).unwrap_or(None),
+            Value::Array(a) => key.parse().map(|i| a.get::<usize>(i)).unwrap_or(None),
             _ => None,
           };
           match value {
@@ -125,7 +125,7 @@ impl MessageTemplate {
       if i > 0 {
         _ = buf.write_str(", ");
       }
-      self.color_format(&mut buf, value);
+      self.color_format(buf, value);
     }
     stylew(buf, &Color::Default.style().dimmed(), "]");
   }

--- a/src/no_color_support.rs
+++ b/src/no_color_support.rs
@@ -21,3 +21,11 @@ pub fn style(s: &Style, t: &str) -> String {
     format!("{}", s.paint(t))
   }
 }
+
+pub fn stylew<W: std::fmt::Write>(mut target: W, s: &Style, t: &str) {
+  if *NO_COLOR {
+    _ = target.write_str(t);
+  } else {
+    _ = write!(target, "{}", s.paint(t));
+  }
+}

--- a/src/no_color_support.rs
+++ b/src/no_color_support.rs
@@ -29,3 +29,11 @@ pub fn stylew<W: std::fmt::Write>(mut target: W, s: &Style, t: &str) {
     _ = write!(target, "{}", s.paint(t));
   }
 }
+
+#[cfg(test)]
+pub fn without_style(styled: &str) -> String {
+    use regex::Regex;
+
+  let regex = Regex::new("\u{001B}\\[[\\d;]*[^\\d;]").expect("Regex should be valid");
+  regex.replace_all(&styled, "").into_owned()
+}

--- a/src/no_color_support.rs
+++ b/src/no_color_support.rs
@@ -32,7 +32,7 @@ pub fn stylew<W: std::fmt::Write>(mut target: W, s: &Style, t: &str) {
 
 #[cfg(test)]
 pub fn without_style(styled: &str) -> String {
-    use regex::Regex;
+  use regex::Regex;
 
   let regex = Regex::new("\u{001B}\\[[\\d;]*[^\\d;]").expect("Regex should be valid");
   regex.replace_all(&styled, "").into_owned()


### PR DESCRIPTION
Hello! This is my own addition to fblog that I use to highlight variables in logs. This makes it much easier to see the relevant data when sifting through lots of almost identical log messages.

Example:
[![asciicast](https://asciinema.org/a/584648.svg)](https://asciinema.org/a/584648)

It was originally modeled to work with JSON representations of [PSR-3 logs](https://www.php-fig.org/psr/psr-3/), hence the `{placeholder}` and `context` being the default values, but it should be dynamic enough to work with several common interpolation formats.

If this something that you would like to include, I can make some adjustments to  make it fit better (and write som tests :)).