### PR TITLE
add config/profile support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,11 +226,14 @@ name = "fblog"
 version = "4.4.0"
 dependencies = [
  "clap",
+ "directories",
  "handlebars",
  "lazy_static",
  "mlua",
  "regex",
+ "serde",
  "serde_json",
+ "toml",
  "yansi",
 ]
 
@@ -221,6 +245,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -238,6 +273,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +289,16 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
 
 [[package]]
 name = "io-lifetimes"
@@ -361,6 +412,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "pest"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +486,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,9 +550,23 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.163"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
@@ -485,6 +576,15 @@ checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
  "serde",
 ]
 
@@ -537,6 +637,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +699,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"
@@ -631,6 +771,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
+ "toml_edit",
  "yansi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ lazy_static = "1.4.0"
 handlebars = "4"
 serde = { version = "1.0.163", features = ["derive"] }
 toml = { version =  "0.7.3", features = [] }
+toml_edit = { version = "0.19" }
 directories = "5.0"
 
 [dependencies.clap]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ regex = "1"
 mlua = { version = "0.8", features = ["lua54", "vendored"] }
 lazy_static = "1.4.0"
 handlebars = "4"
+serde = { version = "1.0.163", features = ["derive"] }
+toml = { version =  "0.7.3", features = [] }
+directories = "5.0"
 
 [dependencies.clap]
 version = "4"

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,6 +8,7 @@ pub fn app() -> Command {
     .version(crate_version!())
     .author("Brocode inc <bros@brocode.sh>")
     .about("json log viewer")
+    .subcommand(Command::new("use-profile").arg(Arg::new("profile").required(true)))
     .arg(
       Arg::new("additional-value")
         .long("additional-value")
@@ -119,9 +120,9 @@ pub fn app() -> Command {
       Arg::new("context-key")
         .long("context-key")
         .short('c')
+        .action(ArgAction::Append)
         .num_args(1)
         .action(ArgAction::Set)
-        .default_value_if("enable-substitution", "true", Substitution::DEFAULT_CONTEXT_KEY)
         .help("Use this key as the source of substitutions for the message. Value can either be an array ({1}) or an object ({key})."),
     )
     .arg(

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,16 @@ pub fn app() -> Command {
     .version(crate_version!())
     .author("Brocode inc <bros@brocode.sh>")
     .about("json log viewer")
-    .subcommand(Command::new("use-profile").arg(Arg::new("profile").required(true)))
+    .subcommand(
+      Command::new("profile").subcommands([
+        Command::new("set")
+          .about("set default options for a profile (uses the same arguments as the root command)")
+          .arg(Arg::new("profile").required(true)),
+        Command::new("use")
+          .about("sets the default profile to the specified value")
+          .arg(Arg::new("profile").required(true)),
+      ]),
+    )
     .arg(
       Arg::new("additional-value")
         .long("additional-value")
@@ -133,5 +142,13 @@ pub fn app() -> Command {
         .action(ArgAction::Set)
         .default_value_if("enable-substitution", "true", Substitution::DEFAULT_PLACEHOLDER_FORMAT)
         .help("The format that should be used for substituting values in the message, where the key is the literal word `key`. Example: [[key]] or ${key}."),
+    )
+    .arg(
+      Arg::new("profile")
+        .long("profile")
+        .short('P')
+        .num_args(1)
+        .action(ArgAction::Set)
+        .help("use values in the specified profile as defaults"),
     )
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,169 @@
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use std::{
+  collections::HashMap,
+  fmt::Display,
+  fs,
+  io::Error as IOError,
+  path::{Path, PathBuf},
+};
+use toml::de::Error as TomlError;
+
+use crate::{log::LogSettings, template};
+
+#[derive(Debug, Deserialize)]
+pub enum Error {
+  FailedToWrite(String),
+  FailedToParse(String),
+  FailedToRead(String),
+  NoDefault,
+}
+
+impl Error {
+  fn failed_to_write<E: Display>(err: E) -> Self {
+    Self::FailedToWrite(err.to_string())
+  }
+}
+
+impl From<TomlError> for Error {
+  fn from(inner: TomlError) -> Self {
+    Self::FailedToParse(inner.to_string())
+  }
+}
+
+impl From<toml::ser::Error> for Error {
+  fn from(inner: toml::ser::Error) -> Self {
+    Self::FailedToWrite(inner.to_string())
+  }
+}
+
+impl From<IOError> for Error {
+  fn from(value: IOError) -> Self {
+    Self::FailedToRead(value.to_string())
+  }
+}
+
+impl Display for Error {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      Self::FailedToParse(e) => {
+        f.write_str("Failed to parse config: ")?;
+        e.fmt(f)
+      }
+      Self::FailedToWrite(e) => {
+        f.write_str("Failed to write config: ")?;
+        e.fmt(f)
+      }
+      Self::FailedToRead(e) => {
+        f.write_str("Failed to read config: ")?;
+        e.fmt(f)
+      }
+      Self::NoDefault => f.write_str("Default config file was not found"),
+    }
+  }
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct Config {
+  pub default_profile: Option<String>,
+  #[serde(rename = "profile")]
+  pub profiles: HashMap<String, Profile>,
+}
+
+impl Config {
+  pub fn config_file_path() -> PathBuf {
+    ProjectDirs::from("org", "brocode", "fblog")
+      .expect("OS home directory")
+      .config_local_dir()
+      .join("config.toml")
+  }
+
+  pub fn load_default() -> Result<Config, Error> {
+    let config_file = Self::config_file_path();
+    if !config_file.exists() {
+      return Ok(Config::default())
+    }
+    Self::load_from_file(&config_file)
+  }
+
+  fn load_from_file(config_file: &Path) -> Result<Config, Error> {
+    let config_str = fs::read_to_string(config_file)?;
+
+    toml::from_str(&config_str)?
+  }
+
+  pub fn get_default_profile(&self) -> Profile {
+    self.profiles.get("default").cloned().unwrap_or_default()
+  }
+
+  pub fn save_default_profile(profile: &str) -> Result<(), Error> {
+    let mut config = Self::load_default().unwrap_or_default();
+    config.default_profile = Some(profile.to_owned());
+    let config_file = Self::config_file_path();
+    if let Some(parent) = config_file.parent() {
+      fs::create_dir_all(parent).map_err(Error::failed_to_write)?;
+    }
+    let config_str = toml::to_string_pretty(&config)?;
+    fs::write(config_file, config_str).map_err(Error::failed_to_write)
+  }
+}
+
+#[derive(Serialize, Deserialize, Default, Clone)]
+pub struct Profile {
+  #[serde(flatten)]
+  pub log_settings: LogSettings,
+
+  #[serde(flatten)]
+  pub template_settings: template::Settings,
+
+  #[serde(skip)]
+  pub maybe_filter: Option<String>,
+
+  #[serde(skip)]
+  pub implicit_return: bool,
+}
+
+pub struct Options {
+  pub log_settings: LogSettings,
+  pub template_settings: template::Settings,
+  pub maybe_filter: Option<String>,
+  pub implicit_return: bool,
+}
+
+impl From<Profile> for Options {
+  fn from(value: Profile) -> Self {
+    Self {
+      implicit_return: true,
+      maybe_filter: None,
+      log_settings: value.log_settings,
+      template_settings: value.template_settings,
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_serialize() {
+    let config: Config = toml::from_str(
+      r#"
+            default_profile = 'foo'
+
+            [profile.foo]
+            message_keys = ['msg']
+
+            [profile.bar]
+            message_keys = ['data']
+        "#,
+    )
+    .expect("input config should parse");
+
+    assert_eq!(config.default_profile, Some("foo".to_owned()));
+    assert!(config.profiles.contains_key("foo"));
+    assert!(config.profiles.contains_key("bar"));
+    assert_eq!(config.profiles.get("foo").map(|p| &p.log_settings.message_keys), Some(&vec!["msg".to_owned()]));
+    assert_eq!(config.profiles.get("bar").map(|p| &p.log_settings.message_keys), Some(&vec!["data".to_owned()]));
+  }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,7 +81,7 @@ impl Config {
   pub fn load_default() -> Result<Config, Error> {
     let config_file = Self::config_file_path();
     if !config_file.exists() {
-      return Ok(Config::default())
+      return Ok(Config::default());
     }
     Self::load_from_file(&config_file)
   }
@@ -115,12 +115,6 @@ pub struct Profile {
 
   #[serde(flatten)]
   pub template_settings: template::Settings,
-
-  #[serde(skip)]
-  pub maybe_filter: Option<String>,
-
-  #[serde(skip)]
-  pub implicit_return: bool,
 }
 
 pub struct Options {

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -1,0 +1,61 @@
+use serde::Deserialize;
+
+use std::{fmt::Display, io::Error as IOError};
+use toml::de::Error as TomlError;
+
+#[derive(Debug, Deserialize)]
+pub enum Error {
+  FailedToWrite(String),
+  FailedToParse(String),
+  FailedToRead(String),
+  NoDefault,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl Error {
+  pub(crate) fn failed_to_write<E: Display>(err: E) -> Self {
+    Self::FailedToWrite(err.to_string())
+  }
+  pub(crate) fn failed_to_read<E: Display>(err: E) -> Self {
+    Self::FailedToRead(err.to_string())
+  }
+}
+
+impl From<TomlError> for Error {
+  fn from(inner: TomlError) -> Self {
+    Self::FailedToParse(inner.to_string())
+  }
+}
+
+impl From<toml::ser::Error> for Error {
+  fn from(inner: toml::ser::Error) -> Self {
+    Self::FailedToWrite(inner.to_string())
+  }
+}
+
+impl From<IOError> for Error {
+  fn from(value: IOError) -> Self {
+    Self::FailedToRead(value.to_string())
+  }
+}
+
+impl Display for Error {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      Self::FailedToParse(e) => {
+        f.write_str("Failed to parse config: ")?;
+        e.fmt(f)
+      }
+      Self::FailedToWrite(e) => {
+        f.write_str("Failed to write config: ")?;
+        e.fmt(f)
+      }
+      Self::FailedToRead(e) => {
+        f.write_str("Failed to read config: ")?;
+        e.fmt(f)
+      }
+      Self::NoDefault => f.write_str("Default config file was not found"),
+    }
+  }
+}

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -1,0 +1,21 @@
+use crate::{log::LogSettings, template};
+
+use super::profile::Profile;
+
+pub struct Options {
+  pub log_settings: LogSettings,
+  pub template_settings: template::Settings,
+  pub maybe_filter: Option<String>,
+  pub implicit_return: bool,
+}
+
+impl From<Profile> for Options {
+  fn from(value: Profile) -> Self {
+    Self {
+      implicit_return: true,
+      maybe_filter: None,
+      log_settings: value.log_settings,
+      template_settings: value.template_settings,
+    }
+  }
+}

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -1,0 +1,91 @@
+use clap::parser::ValueSource;
+use serde::{Deserialize, Serialize};
+use std::{fs, path::PathBuf};
+use toml_edit::{value, Array, Document};
+
+use super::error::{Error, Result};
+use crate::{log::LogSettings, template};
+
+#[derive(Serialize, Deserialize, Default, Clone)]
+pub struct Profile {
+  #[serde(flatten)]
+  pub log_settings: LogSettings,
+
+  #[serde(flatten)]
+  pub template_settings: template::Settings,
+}
+
+impl Profile {
+  fn profile_path(profile: &str) -> PathBuf {
+    super::config_dir().join("profiles").join(PathBuf::from(profile).with_extension("toml"))
+  }
+
+  pub fn load(profile: &str) -> Result<Profile> {
+    let profile_str = fs::read_to_string(Self::profile_path(profile))?;
+
+    toml::from_str(&profile_str)?
+  }
+
+  pub fn update_from_matches(profile: &str, matches: &clap::ArgMatches) -> Result<()> {
+    let profile_file = Self::profile_path(profile);
+    let profile_str = fs::read_to_string(&profile_file).unwrap_or_default();
+    let mut profile = profile_str.parse::<Document>().expect("invalid profile");
+
+    if let Some(values) = matches.get_many::<String>("additional-value") {
+      profile["additional_values"] = value(Array::from_iter(values.cloned()));
+    }
+
+    if let Some(values) = matches.get_many::<String>("message-key") {
+      profile["message_keys"] = value(Array::from_iter(values.cloned()));
+    }
+
+    if let Some(values) = matches.get_many::<String>("time-key") {
+      profile["time_keys"] = value(Array::from_iter(values.cloned()));
+    }
+
+    if let Some(values) = matches.get_many::<String>("level-key") {
+      profile["level_keys"] = value(Array::from_iter(values.cloned()));
+    }
+
+    if let Some(values) = matches.get_many::<String>("context-key") {
+      profile["substitution_enabled"] = value(true); // Substition is implicitly enabled by context keys
+      profile["context_keys"] = value(Array::from_iter(values.cloned()));
+    }
+
+    if let Some(placeholder_format) = matches.get_one::<String>("placeholder-format") {
+      profile["substitution_enabled"] = value(true); // Substition is implicitly enabled by placeholder format
+      profile["placeholder_format"] = value(placeholder_format);
+    }
+
+    if let Some(ValueSource::CommandLine) = matches.value_source("dump-all") {
+      profile["dump_all"] = value(matches.get_flag("dump-all"));
+    }
+    if let Some(ValueSource::CommandLine) = matches.value_source("with-prefix") {
+      profile["with_prefix"] = value(matches.get_flag("with-prefix"));
+    }
+    if let Some(ValueSource::CommandLine) = matches.value_source("print-lua") {
+      profile["print_lua"] = value(matches.get_flag("print-lua"));
+    }
+
+    if let Some(values) = matches.get_many::<String>("excluded-value") {
+      profile["dump_all"] = value(true); // Dump all is implicitly set by exclusion
+      profile["excluded_values"] = value(Array::from_iter(values.cloned()));
+    }
+
+    if let Some(ValueSource::CommandLine) = matches.value_source("main-line-format") {
+      let main_line_format = matches.get_one::<String>("main-line-format").unwrap();
+      profile["main_line_format"] = value(main_line_format);
+    }
+
+    if let Some(ValueSource::CommandLine) = matches.value_source("additional-value-format") {
+      let additional_value_format = matches.get_one::<String>("additional-value-format").unwrap();
+      profile["additional_value_format"] = value(additional_value_format);
+    }
+
+    if let Some(parent) = profile_file.parent() {
+      fs::create_dir_all(parent).map_err(Error::failed_to_write)?;
+    }
+
+    fs::write(profile_file, profile.to_string()).map_err(Error::failed_to_write)
+  }
+}

--- a/src/log.rs
+++ b/src/log.rs
@@ -9,33 +9,22 @@ use std::io::Write;
 use yansi::Color;
 
 #[derive(Serialize, Deserialize, Default, Clone)]
+#[serde(default)]
 pub struct LogSettings {
-  #[serde(default)]
   pub message_keys: Vec<String>,
-  #[serde(default)]
   pub time_keys: Vec<String>,
-  #[serde(default)]
   pub level_keys: Vec<String>,
-  #[serde(default)]
   pub additional_values: Vec<String>,
-  #[serde(default)]
   pub excluded_values: Vec<String>,
-  #[serde(default)]
   pub dump_all: bool,
-  #[serde(default)]
   pub with_prefix: bool,
-  #[serde(default)]
   pub print_lua: bool,
-  #[serde(default)]
   pub substitution_enabled: bool,
-  #[serde(default)]
   pub context_keys: Vec<String>,
-  #[serde(default)]
   pub placeholder_format: String,
 }
 
 impl LogSettings {
-
   const DEFAULT_MESSAGE_KEYS: [&str; 3] = ["short_message", "msg", "message"];
   const DEFAULT_TIME_KEYS: [&str; 3] = ["timestamp", "time", "@timestamp"];
   const DEFAULT_LEVEL_KEYS: [&str; 4] = ["level", "severity", "log.level", "loglevel"];
@@ -247,7 +236,10 @@ mod tests {
     let main_line_format = template::DEFAULT_MAIN_LINE_FORMAT.to_string();
     let additional_value_format = template::DEFAULT_ADDITIONAL_VALUE_FORMAT.to_string();
 
-    template::fblog_handlebar_registry(&template::Settings{main_line_format, additional_value_format})
+    template::fblog_handlebar_registry(&template::Settings {
+      main_line_format,
+      additional_value_format,
+    })
   }
 
   fn out_to_string(out: Vec<u8>) -> String {
@@ -270,6 +262,7 @@ mod tests {
 
     assert_eq!(out_to_string(out), "2017-07-06T15:21:16  INFO: something happend\n");
   }
+
   #[test]
   fn write_log_entry_with_prefix() {
     let handlebars = fblog_handlebar_registry_default_format();

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,37 +1,69 @@
 use crate::no_color_support::style;
 use crate::substitution::Substitution;
 use handlebars::Handlebars;
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::borrow::ToOwned;
 use std::collections::BTreeMap;
 use std::io::Write;
 use yansi::Color;
 
+#[derive(Serialize, Deserialize, Default, Clone)]
 pub struct LogSettings {
+  #[serde(default)]
   pub message_keys: Vec<String>,
+  #[serde(default)]
   pub time_keys: Vec<String>,
+  #[serde(default)]
   pub level_keys: Vec<String>,
+  #[serde(default)]
   pub additional_values: Vec<String>,
+  #[serde(default)]
   pub excluded_values: Vec<String>,
+  #[serde(default)]
   pub dump_all: bool,
+  #[serde(default)]
   pub with_prefix: bool,
+  #[serde(default)]
   pub print_lua: bool,
-  pub substitution: Option<Substitution>,
+  #[serde(default)]
+  pub substitution_enabled: bool,
+  #[serde(default)]
+  pub context_keys: Vec<String>,
+  #[serde(default)]
+  pub placeholder_format: String,
 }
 
 impl LogSettings {
+
+  const DEFAULT_MESSAGE_KEYS: [&str; 3] = ["short_message", "msg", "message"];
+  const DEFAULT_TIME_KEYS: [&str; 3] = ["timestamp", "time", "@timestamp"];
+  const DEFAULT_LEVEL_KEYS: [&str; 4] = ["level", "severity", "log.level", "loglevel"];
+
+  #[cfg(test)]
   pub fn new_default_settings() -> LogSettings {
-    LogSettings {
-      message_keys: vec!["short_message".to_string(), "msg".to_string(), "message".to_string()],
-      time_keys: vec!["timestamp".to_string(), "time".to_string(), "@timestamp".to_string()],
-      level_keys: vec!["level".to_string(), "severity".to_string(), "log.level".to_string(), "loglevel".to_string()],
+    let mut log_settings = LogSettings {
+      message_keys: vec![],
+      time_keys: vec![],
+      level_keys: vec![],
       additional_values: vec![],
       excluded_values: vec![],
       dump_all: false,
       with_prefix: false,
       print_lua: false,
-      substitution: None,
-    }
+      substitution_enabled: false,
+      context_keys: vec![],
+      placeholder_format: Substitution::DEFAULT_PLACEHOLDER_FORMAT.to_owned(),
+    };
+    log_settings.add_default_keys();
+    log_settings
+  }
+
+  pub fn add_default_keys(&mut self) {
+    self.message_keys.extend(Self::DEFAULT_MESSAGE_KEYS.into_iter().map(ToOwned::to_owned));
+    self.time_keys.extend(Self::DEFAULT_TIME_KEYS.into_iter().map(ToOwned::to_owned));
+    self.level_keys.extend(Self::DEFAULT_LEVEL_KEYS.into_iter().map(ToOwned::to_owned));
+    self.context_keys.extend(Substitution::DEFAULT_CONTEXT_KEYS.into_iter().map(ToOwned::to_owned));
   }
 
   pub fn add_additional_values(&mut self, mut additional_values: Vec<String>) {
@@ -57,8 +89,9 @@ impl LogSettings {
     self.excluded_values.append(&mut excluded_values);
   }
 
-  pub fn add_substitution(&mut self, message_template: Substitution) {
-    self.substitution = Some(message_template)
+  pub fn add_context_keys(&mut self, mut context_keys: Vec<String>) {
+    context_keys.append(&mut self.context_keys);
+    self.context_keys = context_keys;
   }
 }
 
@@ -68,6 +101,7 @@ pub fn print_log_line(
   log_entry: &Map<String, Value>,
   log_settings: &LogSettings,
   handlebars: &Handlebars<'static>,
+  substitution: Option<&Substitution>,
 ) {
   let string_log_entry = flatten_json(log_entry, "");
   let level = get_string_value_or_default(&string_log_entry, &log_settings.level_keys, "unknown");
@@ -76,8 +110,8 @@ pub fn print_log_line(
   let mut message = get_string_value_or_default(&string_log_entry, &log_settings.message_keys, "");
   let timestamp = get_string_value_or_default(&string_log_entry, &log_settings.time_keys, "");
 
-  if let Some(message_template) = &log_settings.substitution {
-    if let Some(templated_message) = message_template.apply(&message, log_entry) {
+  if let Some(substitution) = substitution {
+    if let Some(templated_message) = substitution.apply(&message, log_entry) {
       message = templated_message;
     }
   }
@@ -213,7 +247,7 @@ mod tests {
     let main_line_format = template::DEFAULT_MAIN_LINE_FORMAT.to_string();
     let additional_value_format = template::DEFAULT_ADDITIONAL_VALUE_FORMAT.to_string();
 
-    template::fblog_handlebar_registry(main_line_format, additional_value_format)
+    template::fblog_handlebar_registry(&template::Settings{main_line_format, additional_value_format})
   }
 
   fn out_to_string(out: Vec<u8>) -> String {
@@ -232,7 +266,7 @@ mod tests {
     log_entry.insert("process".to_string(), Value::String("rust".to_string()));
     log_entry.insert("level".to_string(), Value::String("info".to_string()));
 
-    print_log_line(&mut out, None, &log_entry, &log_settings, &handlebars);
+    print_log_line(&mut out, None, &log_entry, &log_settings, &handlebars, None);
 
     assert_eq!(out_to_string(out), "2017-07-06T15:21:16  INFO: something happend\n");
   }
@@ -248,7 +282,7 @@ mod tests {
     log_entry.insert("process".to_string(), Value::String("rust".to_string()));
     log_entry.insert("level".to_string(), Value::String("info".to_string()));
 
-    print_log_line(&mut out, Some(prefix), &log_entry, &log_settings, &handlebars);
+    print_log_line(&mut out, Some(prefix), &log_entry, &log_settings, &handlebars, None);
 
     assert_eq!(out_to_string(out), "2017-07-06T15:21:16  INFO: abc something happend\n");
   }
@@ -266,7 +300,7 @@ mod tests {
     let mut log_settings = LogSettings::new_default_settings();
     log_settings.add_additional_values(vec!["process".to_string(), "fu".to_string()]);
 
-    print_log_line(&mut out, None, &log_entry, &log_settings, &handlebars);
+    print_log_line(&mut out, None, &log_entry, &log_settings, &handlebars, None);
 
     assert_eq!(
       out_to_string(out),
@@ -293,7 +327,7 @@ mod tests {
     let mut log_settings = LogSettings::new_default_settings();
     log_settings.add_additional_values(vec!["process".to_string(), "fu".to_string()]);
 
-    print_log_line(&mut out, Some(prefix), &log_entry, &log_settings, &handlebars);
+    print_log_line(&mut out, Some(prefix), &log_entry, &log_settings, &handlebars, None);
 
     assert_eq!(
       out_to_string(out),
@@ -318,7 +352,7 @@ mod tests {
 
     let mut log_settings = LogSettings::new_default_settings();
     log_settings.dump_all = true;
-    print_log_line(&mut out, None, &log_entry, &log_settings, &handlebars);
+    print_log_line(&mut out, None, &log_entry, &log_settings, &handlebars, None);
 
     assert_eq!(
       out_to_string(out),
@@ -350,7 +384,7 @@ mod tests {
     log_settings.add_time_keys(vec!["moep".to_string()]);
     log_settings.add_level_keys(vec!["hugo".to_string()]);
 
-    print_log_line(&mut out, None, &log_entry, &log_settings, &handlebars);
+    print_log_line(&mut out, None, &log_entry, &log_settings, &handlebars, None);
 
     assert_eq!(out_to_string(out), "               moep  HUGO: rust\n");
   }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,4 +1,5 @@
-use crate::filter;
+use crate::substitution::Substitution;
+use crate::{filter, config};
 use crate::log::{self, LogSettings};
 use crate::no_color_support::style;
 use handlebars::Handlebars;
@@ -13,15 +14,14 @@ lazy_static! {
 }
 
 pub fn process_input(
-  log_settings: &LogSettings,
+  options: &config::Options,
   input: &mut dyn io::BufRead,
-  maybe_filter: Option<&String>,
-  implicit_return: bool,
   handlebars: &Handlebars<'static>,
+  substitution: Option<&Substitution>
 ) {
   for line in input.lines() {
     let read_line = &line.expect("Should be able to read line");
-    match process_input_line(log_settings, read_line, None, maybe_filter, implicit_return, handlebars) {
+    match process_input_line(options, read_line, None, handlebars, substitution) {
       Ok(_) => (),
       Err(_) => print_unknown_line(read_line),
     }
@@ -37,25 +37,24 @@ fn print_unknown_line(line: &str) {
 }
 
 fn process_input_line(
-  log_settings: &LogSettings,
+  options: &config::Options,
   read_line: &str,
   maybe_prefix: Option<&str>,
-  maybe_filter: Option<&String>,
-  implicit_return: bool,
   handlebars: &Handlebars<'static>,
+  substitution: Option<&Substitution>,
 ) -> Result<(), ()> {
   match serde_json::from_str::<Value>(read_line) {
     Ok(Value::Object(log_entry)) => {
-      process_json_log_entry(log_settings, maybe_prefix, &log_entry, maybe_filter, implicit_return, handlebars);
+      process_json_log_entry(options, maybe_prefix, &log_entry, handlebars, substitution);
       Ok(())
     }
     _ => {
-      if log_settings.with_prefix && maybe_prefix.is_none() {
+      if options.log_settings.with_prefix && maybe_prefix.is_none() {
         match read_line.find('{') {
           Some(pos) => {
             let prefix = &read_line[..pos];
             let rest = &read_line[pos..];
-            process_input_line(log_settings, rest, Some(prefix), maybe_filter, implicit_return, handlebars)
+            process_input_line(options, rest, Some(prefix), handlebars, substitution)
           }
           None => Err(()),
         }
@@ -67,26 +66,25 @@ fn process_input_line(
 }
 
 fn process_json_log_entry(
-  log_settings: &LogSettings,
+  options: &config::Options,
   maybe_prefix: Option<&str>,
   log_entry: &Map<String, Value>,
-  maybe_filter: Option<&String>,
-  implicit_return: bool,
   handlebars: &Handlebars<'static>,
+  substitution: Option<&Substitution>,
 ) {
-  if let Some(filter) = maybe_filter {
-    match filter::show_log_entry(log_entry, filter, implicit_return, log_settings) {
-      Ok(true) => process_log_entry(log_settings, maybe_prefix, log_entry, handlebars),
+  if let Some(filter) = &options.maybe_filter {
+    match filter::show_log_entry(log_entry, filter, options.implicit_return, &options.log_settings) {
+      Ok(true) => process_log_entry(&options.log_settings, maybe_prefix, log_entry, handlebars, substitution),
       Ok(false) => (),
       Err(e) => {
         writeln!(io::stderr(), "{}: '{:?}'", Color::Red.paint("Failed to apply filter expression"), e).expect("Should be able to write to stderr");
       }
     }
   } else {
-    process_log_entry(log_settings, maybe_prefix, log_entry, handlebars)
+    process_log_entry(&options.log_settings, maybe_prefix, log_entry, handlebars, substitution)
   }
 }
 
-fn process_log_entry(log_settings: &LogSettings, maybe_prefix: Option<&str>, log_entry: &Map<String, Value>, handlebars: &Handlebars<'static>) {
-  log::print_log_line(&mut io::stdout(), maybe_prefix, log_entry, log_settings, handlebars)
+fn process_log_entry(log_settings: &LogSettings, maybe_prefix: Option<&str>, log_entry: &Map<String, Value>, handlebars: &Handlebars<'static>, substitution: Option<&Substitution>) {
+  log::print_log_line(&mut io::stdout(), maybe_prefix, log_entry, log_settings, handlebars, substitution)
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,7 +1,7 @@
-use crate::substitution::Substitution;
-use crate::{filter, config};
 use crate::log::{self, LogSettings};
 use crate::no_color_support::style;
+use crate::substitution::Substitution;
+use crate::{config, filter};
 use handlebars::Handlebars;
 use lazy_static::lazy_static;
 use serde_json::{Map, Value};
@@ -13,12 +13,7 @@ lazy_static! {
   static ref BOLD_ORANGE: Style = Color::RGB(255, 135, 22).style().bold();
 }
 
-pub fn process_input(
-  options: &config::Options,
-  input: &mut dyn io::BufRead,
-  handlebars: &Handlebars<'static>,
-  substitution: Option<&Substitution>
-) {
+pub fn process_input(options: &config::Options, input: &mut dyn io::BufRead, handlebars: &Handlebars<'static>, substitution: Option<&Substitution>) {
   for line in input.lines() {
     let read_line = &line.expect("Should be able to read line");
     match process_input_line(options, read_line, None, handlebars, substitution) {
@@ -85,6 +80,12 @@ fn process_json_log_entry(
   }
 }
 
-fn process_log_entry(log_settings: &LogSettings, maybe_prefix: Option<&str>, log_entry: &Map<String, Value>, handlebars: &Handlebars<'static>, substitution: Option<&Substitution>) {
+fn process_log_entry(
+  log_settings: &LogSettings,
+  maybe_prefix: Option<&str>,
+  log_entry: &Map<String, Value>,
+  handlebars: &Handlebars<'static>,
+  substitution: Option<&Substitution>,
+) {
   log::print_log_line(&mut io::stdout(), maybe_prefix, log_entry, log_settings, handlebars, substitution)
 }

--- a/src/substitution.rs
+++ b/src/substitution.rs
@@ -141,9 +141,7 @@ impl Substitution {
 
 impl Default for Substitution {
   fn default() -> Self {
-    Self::new(
-      Self::default_context_keys(), 
-      Self::DEFAULT_PLACEHOLDER_FORMAT.to_owned()).expect("default placeholder should parse")
+    Self::new(Self::default_context_keys(), Self::DEFAULT_PLACEHOLDER_FORMAT.to_owned()).expect("default placeholder should parse")
   }
 }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,6 +1,6 @@
 use crate::no_color_support::{paint, style};
 use handlebars::{handlebars_helper, no_escape, Handlebars};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use yansi::{Color, Style};
 
@@ -12,16 +12,16 @@ pub struct Settings {
   #[serde(default)]
   pub main_line_format: String,
   #[serde(default)]
-  pub additional_value_format: String
+  pub additional_value_format: String,
 }
 
 impl Default for Settings {
-    fn default() -> Self {
-        Self { 
-          main_line_format: DEFAULT_MAIN_LINE_FORMAT.to_owned(), 
-          additional_value_format: DEFAULT_ADDITIONAL_VALUE_FORMAT.to_owned() 
-        }
+  fn default() -> Self {
+    Self {
+      main_line_format: DEFAULT_MAIN_LINE_FORMAT.to_owned(),
+      additional_value_format: DEFAULT_ADDITIONAL_VALUE_FORMAT.to_owned(),
     }
+  }
 }
 
 fn level_to_style(level: &str) -> Style {

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,10 +1,28 @@
 use crate::no_color_support::{paint, style};
 use handlebars::{handlebars_helper, no_escape, Handlebars};
+use serde::{Serialize, Deserialize};
 use std::convert::TryInto;
 use yansi::{Color, Style};
 
 pub static DEFAULT_MAIN_LINE_FORMAT: &str = "{{bold(fixed_size 19 fblog_timestamp)}} {{level_style (uppercase (fixed_size 5 fblog_level))}}:{{bold(color_rgb 138 43 226 fblog_prefix)}} {{fblog_message}}";
 pub static DEFAULT_ADDITIONAL_VALUE_FORMAT: &str = "{{bold (color_rgb 150 150 150 (fixed_size 25 key))}}: {{value}}";
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Settings {
+  #[serde(default)]
+  pub main_line_format: String,
+  #[serde(default)]
+  pub additional_value_format: String
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self { 
+          main_line_format: DEFAULT_MAIN_LINE_FORMAT.to_owned(), 
+          additional_value_format: DEFAULT_ADDITIONAL_VALUE_FORMAT.to_owned() 
+        }
+    }
+}
 
 fn level_to_style(level: &str) -> Style {
   match level.trim().to_lowercase().as_ref() {
@@ -18,7 +36,7 @@ fn level_to_style(level: &str) -> Style {
   .bold()
 }
 
-pub fn fblog_handlebar_registry(main_line_format: String, additional_value_format: String) -> Handlebars<'static> {
+pub fn fblog_handlebar_registry(settings: &Settings) -> Handlebars<'static> {
   handlebars_helper!(bold: |t: str| {
       style(&Color::Default.style().bold(), t)
   });
@@ -82,9 +100,9 @@ pub fn fblog_handlebar_registry(main_line_format: String, additional_value_forma
   reg.register_helper("green", Box::new(green));
   reg.register_helper("color_rgb", Box::new(color_rgb));
 
-  reg.register_template_string("main_line", main_line_format).expect("Template invalid");
+  reg.register_template_string("main_line", &settings.main_line_format).expect("Template invalid");
   reg
-    .register_template_string("additional_value", additional_value_format)
+    .register_template_string("additional_value", &settings.additional_value_format)
     .expect("Template invalid");
   reg
 }


### PR DESCRIPTION
First draft for config file and profile support. It currently uses the kubectl approach of having a configuration value that determines what the "default" profile is, along with a subcommand to set the profile (`fblog use-profile <PROFILE>`).