### PR TITLE
Add --map-level to rewrite log levels

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -3,3 +3,11 @@ time_keys = ["timestamp", "time", "@timestamp"]
 level_keys = ["level", "severity", "log.level", "loglevel"]
 main_line_format = "{{bold(fixed_size 19 fblog_timestamp)}} {{level_style (uppercase (fixed_size 5 fblog_level))}}:{{#if fblog_prefix}} {{bold(cyan fblog_prefix)}}{{/if}} {{fblog_message}}"
 additional_value_format = "{{bold (color_rgb 150 150 150 (fixed_size 25 key))}}: {{value}}"
+
+[level_map]
+10 = "trace"
+20 = "debug"
+30 = "info"
+40 = "warn"
+50 = "error"
+60 = "fatal"

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,14 @@ use clap::{crate_version, value_parser, ArgAction, ValueHint};
 use clap::{Arg, Command};
 use clap_complete::Shell;
 
+fn parse_key_value_pair(value: &str) -> Result<(String, String), &'static str> {
+    if let Some((from, to)) = value.split_once('=') {
+        Ok((from.to_owned(), to.to_owned()))
+    } else {
+        Err("missing '='")
+    }
+}
+
 pub fn app() -> Command {
     Command::new("fblog")
     .version(crate_version!())
@@ -61,6 +69,15 @@ pub fn app() -> Command {
         .action(ArgAction::Append)
         .num_args(1)
         .help("Adds an additional key to detect the level in the log entry. The first matching key will be assigned to `fblog_level`."),
+    )
+    .arg(
+      Arg::new("map-level")
+        .long("map-level")
+        .action(ArgAction::Append)
+        .num_args(1)
+        .value_name("from=to")
+        .value_parser(parse_key_value_pair)
+        .help("Rewrite the log level from one value to another."),
     )
     .arg(
       Arg::new("dump-all")

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::{fs, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -14,6 +15,18 @@ fn default_time_keys() -> Vec<String> {
 
 fn default_level_keys() -> Vec<String> {
     vec!["level".to_string(), "severity".to_string(), "log.level".to_string(), "loglevel".to_string()]
+}
+
+fn default_level_map() -> BTreeMap<String, String> {
+    BTreeMap::from([
+        // https://www.npmjs.com/package/bunyan#levels
+        ("10".to_string(), "trace".to_string()),
+        ("20".to_string(), "debug".to_string()),
+        ("30".to_string(), "info".to_string()),
+        ("40".to_string(), "warn".to_string()),
+        ("50".to_string(), "error".to_string()),
+        ("60".to_string(), "fatal".to_string()),
+    ])
 }
 
 fn default_main_line_format() -> String {
@@ -34,6 +47,9 @@ pub struct Config {
 
     #[serde(default = "default_level_keys")]
     pub level_keys: Vec<String>,
+
+    #[serde(default = "default_level_map")]
+    pub level_map: BTreeMap<String, String>,
 
     #[serde(default = "default_main_line_format")]
     pub main_line_format: String,
@@ -69,6 +85,7 @@ impl Config {
             message_keys: default_message_keys(),
             time_keys: default_time_keys(),
             level_keys: default_level_keys(),
+            level_map: default_level_map(),
             main_line_format: default_main_line_format(),
             additional_value_format: default_additional_value_format(),
         }
@@ -94,6 +111,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(config.level_keys, default_level_keys());
+        assert_eq!(config.level_map, default_level_map());
         assert_eq!(config.time_keys, default_time_keys());
         assert_eq!(config.message_keys, default_message_keys());
         assert_eq!(config.main_line_format, DEFAULT_MAIN_LINE_FORMAT);

--- a/src/log_settings.rs
+++ b/src/log_settings.rs
@@ -1,9 +1,11 @@
 use crate::{config::Config, substitution::Substitution};
+use std::collections::BTreeMap;
 
 pub struct LogSettings {
     pub message_keys: Vec<String>,
     pub time_keys: Vec<String>,
     pub level_keys: Vec<String>,
+    pub level_map: BTreeMap<String, String>,
     pub additional_values: Vec<String>,
     pub excluded_values: Vec<String>,
     pub dump_all: bool,
@@ -18,6 +20,7 @@ impl LogSettings {
             message_keys: config.message_keys.clone(),
             time_keys: config.time_keys.clone(),
             level_keys: config.level_keys.clone(),
+            level_map: config.level_map.clone(),
             additional_values: vec![],
             excluded_values: vec![],
             dump_all: false,
@@ -50,6 +53,10 @@ impl LogSettings {
     pub fn add_level_keys(&mut self, mut level_keys: Vec<String>) {
         level_keys.append(&mut self.level_keys);
         self.level_keys = level_keys;
+    }
+
+    pub fn add_level_map(&mut self, values: Vec<(String, String)>) {
+        self.level_map.extend(values);
     }
 
     pub fn add_excluded_values(&mut self, mut excluded_values: Vec<String>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,10 @@ fn main() {
         log_settings.add_level_keys(values.map(ToString::to_string).collect());
     }
 
+    if let Some(values) = matches.get_many::<(String, String)>("map-level") {
+        log_settings.add_level_map(values.map(ToOwned::to_owned).collect());
+    }
+
     match (matches.get_one::<String>("context-key"), matches.get_one::<String>("placeholder-format")) {
         (None, None) => {
             // Neither context key nor placeholder is set, meaning that substitution is not enabled

--- a/src/template.rs
+++ b/src/template.rs
@@ -9,10 +9,12 @@ pub static DEFAULT_ADDITIONAL_VALUE_FORMAT: &str = "{{bold (color_rgb 150 150 15
 
 fn level_to_style(level: &str) -> Style {
     match level.trim().to_lowercase().as_ref() {
+        "trace" => Color::Cyan,
+        "debug" => Color::Blue,
         "info" => Color::Green,
         "warn" | "warning" => Color::Yellow,
         "error" | "err" => Color::Red,
-        "debug" => Color::Blue,
+        "fatal" => Color::Magenta,
         _ => Color::Magenta,
     }
     .style()


### PR DESCRIPTION
This allows rewriting the levels in the log to values that are recognized by fblog. Particularly useful when logs contain numeric levels like those generated by Bunyan or syslog.