### PR TITLE
Add colors to --help

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,6 @@
 use crate::substitution::Substitution;
+use clap::builder::Styles;
+use clap::builder::styling::{AnsiColor, Effects};
 use clap::{Arg, Command};
 use clap::{ArgAction, ValueHint, crate_version, value_parser};
 use clap_complete::Shell;
@@ -11,11 +13,18 @@ fn parse_key_value_pair(value: &str) -> Result<(String, String), &'static str> {
 	}
 }
 
+const STYLES: Styles = Styles::styled()
+	.header(AnsiColor::Green.on_default().effects(Effects::BOLD))
+	.usage(AnsiColor::Green.on_default().effects(Effects::BOLD))
+	.literal(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
+	.placeholder(AnsiColor::Cyan.on_default());
+
 pub fn app() -> Command {
 	Command::new("fblog")
 		.version(crate_version!())
 		.author("Brocode inc <bros@brocode.sh>")
 		.about("json log viewer")
+		.styles(STYLES)
 		.arg(
 			Arg::new("additional-value")
 				.long("additional-value")


### PR DESCRIPTION
~I used [clap-cargo](https://github.com/crate-ci/clap-cargo) as it's easy to use and provides sensible default styles.~
User can disable colors via `NO_COLOR=1` environment variable

| before | after | `NO_COLOR=1` |
| - | - | - |
| <img width="1436" height="921" alt="fblog-before" src="https://github.com/user-attachments/assets/442b784d-4b9b-4ebd-a5c5-6a006dac85b0" /> | <img width="1436" height="921" alt="fblog-color" src="https://github.com/user-attachments/assets/1193dd63-c377-481c-b4e8-e919c9b259d2" /> | <img width="1436" height="921" alt="fblog-no-color" src="https://github.com/user-attachments/assets/fcb2203d-16b6-47fb-8b01-1fcc60a5e08e" /> |

Edit: update after screenshot after removing dependency
